### PR TITLE
Reorder popup positioning

### DIFF
--- a/build/layout.js
+++ b/build/layout.js
@@ -35,7 +35,7 @@ axes.row.cross = {
 axes.column.main = axes.row.cross;
 axes.column.cross = axes.row.main;
 
-var types = [{ name: "side", values: ["start", "end"] }, { name: "standing", values: ["above", "right", "below", "left"] }, { name: "flow", values: ["column", "row"] }];
+var types = [{ name: "side", values: ["start", "end"] }, { name: "standing", values: ["above", "below"] }, { name: "flow", values: ["column", "row"] }];
 
 var validTypeValues = types.reduce(function (xs, _ref) {
   var values = _ref.values;
@@ -150,20 +150,6 @@ var pickZone = function pickZone(opts, frameBounds, targetBounds, size) {
     order: -1,
     w: f.x2,
     h: t.y
-  }, {
-    side: "end",
-    standing: "right",
-    flow: "row",
-    order: 1,
-    w: f.x2 - t.x2,
-    h: f.y2
-  }, {
-    side: "start",
-    standing: "left",
-    flow: "row",
-    order: -1,
-    w: t.x,
-    h: f.y2
   }];
 
   /* Order the zones by the amount of popup that would be cut out if that zone is used.

--- a/build/layout.js
+++ b/build/layout.js
@@ -137,6 +137,13 @@ var pickZone = function pickZone(opts, frameBounds, targetBounds, size) {
   var t = targetBounds;
   var f = frameBounds;
   var zones = [{
+    side: "end",
+    standing: "below",
+    flow: "column",
+    order: 1,
+    w: f.x2,
+    h: f.y2 - t.y2
+  }, {
     side: "start",
     standing: "above",
     flow: "column",
@@ -150,13 +157,6 @@ var pickZone = function pickZone(opts, frameBounds, targetBounds, size) {
     order: 1,
     w: f.x2 - t.x2,
     h: f.y2
-  }, {
-    side: "end",
-    standing: "below",
-    flow: "column",
-    order: 1,
-    w: f.x2,
-    h: f.y2 - t.y2
   }, {
     side: "start",
     standing: "left",

--- a/source/layout.js
+++ b/source/layout.js
@@ -27,7 +27,7 @@ axes.column.cross = axes.row.main
 
 const types = [
   { name: "side", values: ["start", "end"] },
-  { name: "standing", values: ["above", "right", "below", "left"] },
+  { name: "standing", values: ["above", "below"] },
   { name: "flow", values: ["column", "row"] },
 ]
 
@@ -148,22 +148,6 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
       order: -1,
       w: f.x2,
       h: t.y,
-    },
-    {
-      side: "end",
-      standing: "right",
-      flow: "row",
-      order: 1,
-      w: f.x2 - t.x2,
-      h: f.y2,
-    },
-    {
-      side: "start",
-      standing: "left",
-      flow: "row",
-      order: -1,
-      w: t.x,
-      h: f.y2,
     },
   ]
 

--- a/source/layout.js
+++ b/source/layout.js
@@ -134,6 +134,14 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
   const f = frameBounds
   const zones = [
     {
+      side: "end",
+      standing: "below",
+      flow: "column",
+      order: 1,
+      w: f.x2,
+      h: f.y2 - t.y2,
+    },
+    {
       side: "start",
       standing: "above",
       flow: "column",
@@ -148,14 +156,6 @@ const pickZone = (opts, frameBounds, targetBounds, size) => {
       order: 1,
       w: f.x2 - t.x2,
       h: f.y2,
-    },
-    {
-      side: "end",
-      standing: "below",
-      flow: "column",
-      order: 1,
-      w: f.x2,
-      h: f.y2 - t.y2,
     },
     {
       side: "start",


### PR DESCRIPTION
#MAJOR#

# CHANGELOG
* Reorder popup positioning in the following order:
1. Below
2. Above

* Removed support for `left` & `right` rendering